### PR TITLE
Features/ast refactor of ft_handle_redirections (#38)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ exec_test
 ast_test
 exec
 test_parser
+refactor_parser

--- a/Makefile
+++ b/Makefile
@@ -81,14 +81,18 @@ exec: $(PATH_OBJS_EXEC) $(LFT)
 test_parser: $(PATH_OBJS_AST) $(PATH_OBJS_LEXER) $(LFT)
 	$(CC) $(CFLAGS) $(TESTER_DIR)/parser.c $^ -o $@
 
+refactor_parser: $(PATH_OBJS_AST) $(PATH_OBJS_LEXER) $(LFT)
+	$(CC) $(CFLAGS) $(TESTER_DIR)/refactor_parser.c $^ -o $@
+
 $(AST_NAME): $(PATH_OBJS_AST) $(PATH_OBJS_LEXER) $(LFT)
 	$(CC) $(CFLAGS) $(TESTER_DIR)/ast_tester.c $^ -o $@
 
-$(NAME): $(PATH_OBJS_LEXER) $(LFT)
+$(NAME): $(PATH_OBJS_AST) $(PATH_OBJS_LEXER) $(LFT)
 	$(CC) $(CFLAGS) -lreadline src/test_module/shell.c $^ -o $(NAME)
 
 $(LFT):
 	$(MAKE) -C libft
+	$(MAKE) -C libft bonus
 
 $(OBJS_DIR)/lexer/%.o:$(LEXER_DIR)/%.c | $(OBJS_DIR)/lexer
 	$(CC) $(CFLAGS) -c $< -o $@
@@ -121,10 +125,12 @@ fclean: clean
 	rm -rf $(UNIT)
 	rm -rf $(EXEC)
 	rm -rf $(AST_NAME)
+	rm -rf test_parser
+	rm -rf refactor_parser
 
 re: fclean all
 
 vgr: all
 	valgrind --leak-check=full --show-leak-kinds=all --suppressions=./readline.supp ./$(NAME)
 
-.PHONY: all clean fclean re unit vgr exec test_parser
+.PHONY: all clean fclean re unit vgr exec test_parser refactor_parser

--- a/include/ast.h
+++ b/include/ast.h
@@ -7,7 +7,6 @@ t_ast		*ft_ast_node_command(t_cmd *cmd);
 t_ast		*ft_ast_generic_node(t_node_type type);
 t_parser	*ft_init_parser(t_lexer *l);
 t_cmd		*ft_create_command(char **av, t_redir *redirs, int count);
-t_redir		*ft_create_redir_lst(t_label_redir label, char *str);
 void		ft_parser_iter(t_parser *parser);
 
 t_ast		*ft_parser(t_lexer *l);
@@ -18,11 +17,12 @@ t_ast		*ft_parse_node_command(t_parser *parser);
 t_ast		*ft_parse_subshell(t_parser *parser);
 char		**ft_parse_args(t_parser *parser);
 char		**ft_lst_to_args(t_list **head, int size);
-int			ft_handle_redirects(t_parser *parser, t_redir **head_redir);
-void		ft_redirs_addback(t_redir **head, t_redir *new);
+int			ft_handle_redirects(t_parser *parser, t_cmd *cmd_to_fill);
+t_redir		*ft_create_redir(t_label_redir label, char *str);
+void		ft_free_redir_struct_only(void *content);
+void		ft_free_redir_content(void *content);
+void		ft_copy_lst_to_array(t_list *head, t_redir *array);
 
-void		ft_redirs_clear(t_redir **redirs);
-void		ft_free_redir_lst(t_redir *redir);
 void		ft_free_array(char **arr);
 void		ft_free_cmd(t_cmd *cmd);
 void		ft_free_ast(t_ast *root);

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -1,6 +1,8 @@
 #ifndef LEXER_H
 #define LEXER_H
 
+# include "libshell.h"
+
 t_lexer	*ft_state_lexer(char *line);
 t_token	*get_next_token(t_lexer *l);
 t_token	*ft_handle_operator(t_lexer *l);

--- a/include/libshell.h
+++ b/include/libshell.h
@@ -92,7 +92,6 @@ typedef struct s_redir
 {
 	char			*file_name;
 	t_label_redir	label;
-	struct s_redir	*next;
 }	t_redir;
 
 typedef struct s_cmd

--- a/src/ast/core.c
+++ b/src/ast/core.c
@@ -1,3 +1,4 @@
+#include "libshell.h"
 #include "ast.h"
 #include "lexer.h"
 
@@ -9,18 +10,18 @@ t_ast	*ft_parser(t_lexer *l)
 	parser = ft_init_parser(l);
 	if (!parser)
 	{
-		fprintf(stderr, "Error parser allocate.");
+		fprintf(stderr, "Error parser allocate.\n");
 		return (NULL);
 	}
 	ast_root = ft_parse_and_or(parser); // Search lowest precedence
 	if (ast_root != NULL && parser->current_token->tok_label != TOKEN_EOF)
 	{
-		fprintf(stderr, "Error creating tree.");
+		fprintf(stderr, "Syntax error near unexpected token: %s.\n", parser->current_token->str);
 		ft_free_ast(ast_root);
 		ast_root = NULL;
 	}
-	free(parser->current_token);
-	free(parser->peek);
+	free_token(parser->current_token);
+	free_token(parser->peek);
 	free(parser);
 	return (ast_root);
 }
@@ -84,6 +85,7 @@ t_ast	*ft_parse_pipeline(t_parser *parser)
 t_ast	*ft_parse_grain_with_redirs(t_parser *parser)
 {
 	t_ast	*node;
+	t_cmd	*cmd_to_fill;
 
 	node = NULL;
 	if (parser->current_token->tok_label == TOKEN_LEFT_PAR)
@@ -91,7 +93,7 @@ t_ast	*ft_parse_grain_with_redirs(t_parser *parser)
 	else if (parser->current_token->tok_label == TOKEN_WORD)
 		node = ft_parse_node_command(parser);
 	else
-		fprintf(stderr, "Error invalid token.");
+		fprintf(stderr, "Error invalid token.\n");
 	if (!node)
 		return (NULL);
 	if (node->type == NODE_SUBSHELL)
@@ -100,7 +102,8 @@ t_ast	*ft_parse_grain_with_redirs(t_parser *parser)
 		if (!node->cmd)
 			return (ft_free_ast(node), NULL);
 	}
-	if (ft_handle_redirects(parser, &node->cmd->redirs) == false)
+	cmd_to_fill = node->cmd;
+	if (ft_handle_redirects(parser, cmd_to_fill) == false)
 		return (ft_free_ast(node), NULL);
 	return (node);
 }
@@ -173,36 +176,88 @@ int	ft_isredir(t_parser *parser)
 			parser->current_token->tok_label == TOKEN_REDIR_HEREDOC);
 }
 
-int	ft_handle_redirects(t_parser *parser, t_redir **head_redir)
+static
+t_label_redir	ft_label_map(t_token_label label)
 {
-	t_redir *new_redir;
+	if (label == TOKEN_REDIR_IN)
+		return (REDIR_IN);
+	else if (label == TOKEN_REDIR_OUT)
+		return (REDIR_OUT);
+	else if (label == TOKEN_REDIR_APPEND)
+		return (REDIR_APPEND);
+	else if (label == TOKEN_REDIR_HEREDOC)
+		return (REDIR_HEREDOCK);
+	return (REDIR_NONE);
+}
 
+int	ft_handle_redirects(t_parser *parser, t_cmd *cmd_to_fill)
+{
+	t_redir			*new_redir;
+	t_list			*tmp_lst_head;
+	t_list			*new_link;
+	t_label_redir	label;
+	char			*filename;
+	
+	tmp_lst_head = NULL;
 	while (ft_isredir(parser))
 	{
-		if (parser->peek->tok_label == TOKEN_WORD)
-		{
-			if (parser->current_token->tok_label == TOKEN_REDIR_IN)
-				new_redir = ft_create_redir_lst(REDIR_IN, ft_strdup(parser->peek->str));
-			else if (parser->current_token->tok_label == TOKEN_REDIR_OUT)
-				new_redir = ft_create_redir_lst(REDIR_OUT, ft_strdup(parser->peek->str));
-			else if (parser->current_token->tok_label == TOKEN_REDIR_APPEND)
-				new_redir = ft_create_redir_lst(REDIR_APPEND, ft_strdup(parser->peek->str));
-			else if (parser->current_token->tok_label == TOKEN_REDIR_HEREDOC)
-				new_redir = ft_create_redir_lst(REDIR_HEREDOCK, ft_strdup(parser->peek->str));
-		}
+		label = ft_label_map(parser->current_token->tok_label);
+		if (label == REDIR_HEREDOCK)
+			filename = ft_strdup(parser->current_token->str);
 		else
-			return (fprintf(stderr, "Syntax error near token"), ft_redirs_clear(head_redir), false);
+		{
+			if (parser->peek->tok_label != TOKEN_WORD)
+				return (ft_lstclear(&tmp_lst_head, &ft_free_redir_content), false);
+			filename = ft_strdup(parser->peek->str);
+		}
+		if (!filename)
+			return (ft_lstclear(&tmp_lst_head, &ft_free_redir_content), false);
+		new_redir = ft_create_redir(label, filename);
 		if (!new_redir)
-			return (ft_redirs_clear(head_redir), false);
-		ft_redirs_addback(head_redir, new_redir);
+			return (ft_lstclear(&tmp_lst_head, &ft_free_redir_content), false);
+		new_link = ft_lstnew(new_redir);
+		if (!new_link)
+			return (ft_free_redir_content(new_redir), \
+					ft_lstclear(&tmp_lst_head, &ft_free_redir_content), false);
+		ft_lstadd_back(&tmp_lst_head, new_link);
+		cmd_to_fill->redir_count++;
 		ft_parser_iter(parser);
-		ft_parser_iter(parser);
+		if (label != REDIR_HEREDOCK)
+			ft_parser_iter(parser);
+	}
+	if (cmd_to_fill->redir_count > 0)
+	{
+		cmd_to_fill->redirs = (t_redir *)ft_calloc(cmd_to_fill->redir_count, \
+				sizeof(t_redir));
+		if (!cmd_to_fill->redirs)
+			return (ft_lstclear(&tmp_lst_head, &ft_free_redir_content), false);
+		ft_copy_lst_to_array(tmp_lst_head, cmd_to_fill->redirs);
+		ft_lstclear(&tmp_lst_head, &ft_free_redir_struct_only);
 	}
 	return (true);
 }
 
 t_ast	*ft_parse_subshell(t_parser *parser)
 {
-	fprintf(stdout, "%s\n", parser->current_token->str);
-	return (NULL);
+	t_ast	*node_subsh;
+	t_ast	*body;
+
+	if (parser->peek->tok_label == TOKEN_RIGHT_PAR)
+	{
+		ft_parser_iter(parser);
+		ft_parser_iter(parser);
+		return (fprintf(stderr, "Syntax error near token \")\".\n"), NULL);
+	}
+	ft_parser_iter(parser);
+	body = ft_parse_and_or(parser);
+	if (!body)
+		return (fprintf(stderr, "Error in subshell body.\n"), NULL);
+	if (parser->current_token->tok_label != TOKEN_RIGHT_PAR)
+		return (fprintf(stderr, "Error unclosed parenthese.\n"), ft_free_ast(body), NULL);
+	ft_parser_iter(parser);
+	node_subsh = ft_ast_generic_node(NODE_SUBSHELL);
+	if (!node_subsh)
+		return (ft_free_ast(body), NULL);
+	node_subsh->body = body;
+	return (node_subsh);
 }

--- a/src/ast/ft_ast.c
+++ b/src/ast/ft_ast.c
@@ -1,3 +1,4 @@
+#include "libshell.h"
 #include "ast.h"
 #include "lexer.h"
 
@@ -79,46 +80,43 @@ t_cmd	*ft_create_command(char	**av, t_redir *redirs, int count)
 	return (new_cmd);
 }
 
-t_redir	*ft_create_redir_lst(t_label_redir label, char *str)
+t_redir	*ft_create_redir(t_label_redir label, char *str)
 {
 	t_redir	*r;
 
 	r = (t_redir *)ft_calloc(1, sizeof(t_redir));
 	if (!r)
-		return (NULL);
+		return (free(str), NULL);
 	r->label = label;
 	r->file_name = str;
-	r->next = NULL;
 	return (r);
 }
 
-void	ft_redirs_addback(t_redir **head, t_redir *new)
+void	ft_free_redir_content(void *content)
 {
-	t_redir	*ptr;
+	t_redir	*redir;
 
-	if (!*head && new)
-	{
-		*head = new;
+	redir = (t_redir *)content;
+	if (!redir)
 		return ;
-	}
-	if (!new)
-		return ;
-	ptr = *head;
-	while (ptr)
-		ptr = ptr->next;
-	ptr->next = new;
+	free(redir->file_name);
+	free(redir);
 }
 
-void	ft_redirs_clear(t_redir **redirs)
+void	ft_copy_lst_to_array(t_list *head, t_redir *array)
 {
-	t_redir	*tmp;
+	int		i;
+	t_list	*tmp;
+	t_redir	*redir_to_arr;
 
-	while (redirs)
+	i = 0;
+	tmp = head;
+	while (tmp)
 	{
-		tmp = (*redirs)->next;
-		free((*redirs)->file_name);
-		free(*redirs);
-		*redirs = tmp;
+		redir_to_arr = (t_redir *)tmp->content;
+		array[i].label = redir_to_arr->label;
+		array[i].file_name = redir_to_arr->file_name;
+		i++;
+		tmp = tmp->next;
 	}
-	*redirs = NULL;
 }

--- a/src/ast/guards.c
+++ b/src/ast/guards.c
@@ -1,20 +1,6 @@
+#include "libshell.h"
 #include "ast.h"
 #include "lexer.h"
-
-void	ft_free_redir_lst(t_redir *redir)
-{
-	t_redir	*tmp;
-
-	if (!redir)
-		return ;
-	while (redir)
-	{
-		tmp = redir->next;
-		free(redir->file_name);
-		free(redir);
-		redir = tmp;
-	}
-}
 
 void	ft_free_array(char **arr)
 {
@@ -30,10 +16,21 @@ void	ft_free_array(char **arr)
 
 void	ft_free_cmd(t_cmd *cmd)
 {
+	int	i;
+
 	if (!cmd)
 		return ;
 	ft_free_array(cmd->args);
-	ft_free_redir_lst(cmd->redirs);
+	if (cmd->redirs)
+	{
+		i = 0;
+		while (i < cmd->redir_count)
+		{
+			free(cmd->redirs[i].file_name);
+			i++;
+		}
+		free(cmd->redirs);
+	}
 	free(cmd);
 }
 
@@ -50,4 +47,14 @@ void	ft_free_ast(t_ast *root)
 		ft_free_ast(root->body);
 	ft_free_cmd(root->cmd);
 	free(root);
+}
+
+void    ft_free_redir_struct_only(void *content)
+{
+	t_redir *redir;
+
+	redir = (t_redir *)content;
+	if (!redir)
+		return;
+	free(redir);
 }

--- a/src/test_module/parser_integration.c
+++ b/src/test_module/parser_integration.c
@@ -1,0 +1,200 @@
+#include "ast.h"    // Your AST/Parser headers
+#include "lexer.h"  // Your Lexer headers
+#include <stdio.h>    // For printf
+#include <string.h>   // For strdup, strcmp
+
+/*
+ * ===================================================================
+ * AST PRETTY-PRINTER (For Test Verification)
+ * ===================================================================
+ * A robust print_ast is necessary to verify the tree.
+ */
+
+static void print_indent(int depth)
+{
+    for (int i = 0; i < depth; i++)
+        printf("  ");
+}
+
+static const char *redir_label_to_str(t_label_redir label)
+{
+    if (label == REDIR_IN) return "<";
+    if (label == REDIR_OUT) return ">";
+    if (label == REDIR_APPEND) return ">>";
+    if (label == REDIR_HEREDOCK) return "<<";
+    return "?";
+}
+
+// Helper to print a command's args and redirections
+static void print_command_details(t_cmd *cmd, int depth)
+{
+    if (!cmd)
+        return;
+
+    // Print Args
+    if (cmd->args)
+    {
+        print_indent(depth);
+        printf("Args: ");
+        for (int i = 0; cmd->args[i]; i++)
+            printf("[%s] ", cmd->args[i]);
+        printf("\n");
+    }
+
+    // Print Redirections
+    if (cmd->redirs)
+    {
+        print_indent(depth);
+        printf("Redirs: ");
+        t_redir *r = cmd->redirs;
+        while (r)
+        {
+            printf("(%s %s) ", redir_label_to_str(r->label), r->file_name);
+            r = r->next;
+        }
+        printf("\n");
+    }
+}
+
+// Main recursive AST printer
+void print_ast(t_ast *node, int depth)
+{
+    if (!node)
+    {
+        print_indent(depth);
+        printf("(NULL NODE)\n");
+        return;
+    }
+
+    print_indent(depth);
+
+    switch (node->type)
+    {
+        case NODE_PIPE:
+            printf("PIPE\n");
+            print_ast(node->left, depth + 1);
+            print_ast(node->right, depth + 1);
+            break;
+        case NODE_AND:
+            printf("AND (&&)\n");
+            print_ast(node->left, depth + 1);
+            print_ast(node->right, depth + 1);
+            break;
+        case NODE_OR:
+            printf("OR (||)\n");
+            print_ast(node->left, depth + 1);
+            print_ast(node->right, depth + 1);
+            break;
+        case NODE_CMD:
+            printf("COMMAND\n");
+            print_command_details(node->cmd, depth + 1);
+            break;
+        case NODE_SUBSHELL:
+            printf("SUBSHELL ( ... )\n");
+            // Print redirections attached *to the subshell*
+            print_command_details(node->cmd, depth + 1);
+            // Print the subshell's body
+            print_ast(node->body, depth + 1);
+            break;
+        default:
+            printf("UNKNOWN NODE TYPE\n");
+    }
+}
+
+/*
+ * ===================================================================
+ * TEST HARNESS
+ * ===================================================================
+ */
+
+// Helper to run a single test case
+void run_test(char *input_line)
+{
+    t_lexer *lexer;
+    t_ast   *ast_root;
+    
+    // We need a mutable copy for the lexer
+    char *input_copy = strdup(input_line);
+
+    printf("\n======================================================\n");
+    printf("TESTING: %s\n", input_line);
+    printf("------------------------------------------------------\n");
+
+    lexer = ft_state_lexer(input_copy);
+    if (!lexer)
+    {
+        printf("TEST FAILED: Lexer initialization returned NULL.\n");
+        free(input_copy);
+        return;
+    }
+
+    ast_root = ft_parser(lexer);
+
+    if (ast_root == NULL)
+    {
+        printf("AST: [NULL] (Syntax Error Detected)\n");
+    }
+    else
+    {
+        print_ast(ast_root, 0);
+    }
+
+    // Full cleanup
+    ft_free_ast(ast_root);
+    free_lexer(lexer); // Assumes you have a free_lexer
+    free(input_copy);
+}
+
+int main(void)
+{
+    // --- Category 1: Simple Commands ---
+    run_test("ls");
+    run_test("ls -la /tmp");
+
+    // --- Category 2: Redirections ---
+    run_test("cat < in.txt");
+    run_test("echo hello > out.txt");
+    run_test("grep a << EOF");
+    run_test("echo append >> log.txt");
+    run_test("cmd < in1 > out1 < in2 >> out2"); // Multiple and order
+    
+    // --- Category 3: Pipes ---
+    run_test("ls | wc -l");
+    run_test("cmd1 | cmd2 | cmd3"); // Left-associativity
+    run_test("cat < in.txt | grep 'a' | wc -l > out.txt"); // Pipes + Redirs
+
+    // --- Category 4: Boolean Operators (&& ||) ---
+    run_test("ls && echo ok");
+    run_test("ls || echo failed");
+    run_test("cmd1 && cmd2 || cmd3"); // Associativity: (cmd1 && cmd2) || cmd3
+    run_test("cmd1 || cmd2 && cmd3"); // Associativity: (cmd1 || cmd2) && cmd3
+    
+    // --- Category 5: Precedence (Pipes vs. Booleans) ---
+    run_test("ls | wc && cat file"); // (ls | wc) && (cat file)
+    run_test("cat file && ls | wc"); // (cat file) && (ls | wc)
+    run_test("cmd1 | cmd2 && cmd3 | cmd4"); // (cmd1 | cmd2) && (cmd3 | cmd4)
+
+    // --- Category 6: Subshells (Parentheses) ---
+    run_test("(ls)");
+    run_test("(ls | wc -l)"); // Pipe in subshell
+    run_test("(ls && echo ok) || echo failed"); // Boolean in subshell
+    run_test("(ls) > out.txt"); // Redir ON subshell
+    run_test("(ls > in.txt) > out.txt"); // Redir IN and ON subshell
+    
+    // --- Category 7: Complex Combinations ---
+    run_test("(cmd1 < in && (cmd2 | cmd3)) > out || cmd4 << EOF");
+
+    // --- Category 8: Syntax Errors (Should return NULL) ---
+    run_test("| ls");
+    run_test("ls |");
+    run_test("ls | | wc");
+    run_test("&& ls");
+    run_test("ls &&");
+    run_test("ls >");
+    run_test("ls > | wc");
+    run_test("(ls");
+    run_test("ls )");
+    run_test("()");
+
+    return (0);
+}

--- a/src/test_module/refactor_parser.c
+++ b/src/test_module/refactor_parser.c
@@ -1,0 +1,241 @@
+#include "ast.h"    // Your AST/Parser headers
+#include "lexer.h"  // Your Lexer headers
+#include <stdio.h>    // For printf
+#include <string.h>   // For strdup, strcmp
+
+/*
+ * ===================================================================
+ * YOUR FUNCTION PROTOTYPES (Assumed to exist)
+ * ===================================================================
+ */
+
+// From Lexer (or libshell.h)
+t_lexer *ft_state_lexer(char *line);
+void    free_lexer(t_lexer *l); // Make sure you have this!
+void    free_token(t_token *t); // Make sure you have this!
+// ... and all your libft functions (ft_strdup, etc.)
+
+// From Parser (core.txt, ft_ast.txt, guards.txt)
+t_ast   *ft_parser(t_lexer *l);
+void    ft_free_ast(t_ast *root);
+void	ft_free_redir_content(void *content);
+void    ft_free_redir_struct_only(void *content);
+
+
+/*
+ * ===================================================================
+ * AST PRETTY-PRINTER (For Test Verification)
+ * ===================================================================
+ * This printer is built to match your exact structs.
+ */
+
+static void print_indent(int depth)
+{
+	for (int i = 0; i < depth; i++)
+		printf("  ");
+}
+
+static const char *redir_label_to_str(t_label_redir label)
+{
+	if (label == REDIR_IN) return "<";
+	if (label == REDIR_OUT) return ">";
+	if (label == REDIR_APPEND) return ">>";
+	if (label == REDIR_HEREDOCK) return "<<";
+	return "?";
+}
+
+// Helper to print a command's args and its REDIRECTION ARRAY
+static void print_command_details(t_cmd *cmd, int depth)
+{
+	if (!cmd)
+		return;
+
+	// Print Args
+	if (cmd->args)
+	{
+		print_indent(depth);
+		printf("Args: ");
+		for (int i = 0; cmd->args[i]; i++)
+			printf("[%s] ", cmd->args[i]);
+		printf("\n");
+	}
+
+	// Print Redirections (from the array)
+	if (cmd->redirs && cmd->redir_count > 0)
+	{
+		print_indent(depth);
+		printf("Redirs (count: %d): ", cmd->redir_count);
+		for (int i = 0; i < cmd->redir_count; i++)
+		{
+			// Access the struct *at the array index*
+			t_redir *r = &cmd->redirs[i];
+			printf("(%s %s) ", redir_label_to_str(r->label), r->file_name);
+		}
+		printf("\n");
+	}
+}
+
+// Main recursive AST printer
+void print_ast(t_ast *node, int depth)
+{
+	if (!node)
+	{
+		print_indent(depth);
+		printf("(NULL NODE)\n");
+		return;
+	}
+
+	print_indent(depth);
+
+	switch (node->type)
+	{
+		case NODE_PIPE:
+			printf("PIPE\n");
+			print_ast(node->left, depth + 1);
+			print_ast(node->right, depth + 1);
+			break;
+		case NODE_AND:
+			printf("AND (&&)\n");
+			print_ast(node->left, depth + 1);
+			print_ast(node->right, depth + 1);
+			break;
+		case NODE_OR:
+			printf("OR (||)\n");
+			print_ast(node->left, depth + 1);
+			print_ast(node->right, depth + 1);
+			break;
+		case NODE_CMD:
+			printf("COMMAND\n");
+			print_command_details(node->cmd, depth + 1);
+			break;
+		case NODE_SUBSHELL:
+			printf("SUBSHELL ( ... )\n");
+			// A subshell can have its *own* redirections
+			print_command_details(node->cmd, depth + 1);
+			// And it has a body
+			print_indent(depth);
+			printf("Body:\n");
+			print_ast(node->body, depth + 1);
+			break;
+		default:
+			printf("UNKNOWN NODE TYPE\n");
+	}
+}
+
+/*
+ * ===================================================================
+ * TEST HARNESS
+ * ===================================================================
+ */
+
+// Helper to run a single test case
+static int run_test(char *input_line)
+{
+	t_lexer *lexer;
+	t_ast   *ast_root;
+	int     success = 1;
+	
+	// We need a mutable copy for the lexer
+	char *input_copy = ft_strdup(input_line);
+	if (!input_copy)
+	{
+		printf("FATAL: strdup failed in test harness.\n");
+		return (0);
+	}
+
+	printf("\n======================================================\n");
+	printf("TESTING: %s\n", input_line);
+	printf("------------------------------------------------------\n");
+
+	lexer = ft_state_lexer(input_copy);
+	if (!lexer)
+	{
+		printf("TEST FAILED: Lexer initialization returned NULL.\n");
+		free(input_copy);
+		return (0);
+	}
+
+	ast_root = ft_parser(lexer);// This calls your entry point [cite: 24]
+
+	if (ast_root == NULL)
+	{
+		printf("AST: [NULL] (Syntax Error Detected)\n");
+		// This is the *correct* outcome for syntax error tests
+	}
+	else
+	{
+		print_ast(ast_root, 0);
+	}
+
+	// Full cleanup
+	ft_free_ast(ast_root);
+	free_lexer(lexer); // You must provide this
+	free(input_copy);
+	
+	// This is a simple verification. A real test would compare
+	// the AST to an expected structure.
+	return (success);
+}
+
+int main(void)
+{
+	int pass_count = 0;
+	int total_tests = 0;
+
+	// --- Category 1: Simple Commands ---
+	total_tests++; pass_count += run_test("ls");
+	total_tests++; pass_count += run_test("ls -la /tmp");
+
+	// --- Category 2: Redirections (Tests the new array) ---
+	total_tests++; pass_count += run_test("cat < in.txt");
+	total_tests++; pass_count += run_test("echo hello > out.txt");
+	total_tests++; pass_count += run_test("grep a << EOF");
+	total_tests++; pass_count += run_test("echo append >> log.txt");
+	total_tests++; pass_count += run_test("cmd < in1 > out1 < in2 >> out2"); // CRITICAL: Multiple redirs
+	
+	// --- Category 3: Pipes ---
+	total_tests++; pass_count += run_test("ls | wc -l");
+	total_tests++; pass_count += run_test("cmd1 | cmd2 | cmd3"); // Left-associativity
+	total_tests++; pass_count += run_test("cat < in.txt | grep 'a' | wc -l > out.txt"); // Pipes + Redirs
+
+	// --- Category 4: Boolean Operators (&& ||) ---
+	total_tests++; pass_count += run_test("ls && echo ok");
+	total_tests++; pass_count += run_test("ls || echo failed");
+	total_tests++; pass_count += run_test("cmd1 && cmd2 || cmd3"); // Associativity: (cmd1 && cmd2) || cmd3
+	total_tests++; pass_count += run_test("cmd1 || cmd2 && cmd3"); // Associativity: (cmd1 || cmd2) && cmd3
+	
+	// --- Category 5: Precedence (Pipes vs. Booleans) ---
+	total_tests++; pass_count += run_test("ls | wc && cat file"); // (ls | wc) && (cat file)
+	total_tests++; pass_count += run_test("cat file && ls | wc"); // (cat file) && (ls | wc)
+	
+	// --- Category 6: Subshells (The other major feature) ---
+	total_tests++; pass_count += run_test("(ls)");
+	total_tests++; pass_count += run_test("(ls | wc -l)"); // Pipe in subshell
+	total_tests++; pass_count += run_test("(ls && echo ok) || echo failed"); // Boolean in subshell
+	total_tests++; pass_count += run_test("(ls) > out.txt"); // CRITICAL: Redir ON subshell
+	total_tests++; pass_count += run_test("(ls > in.txt) > out.txt"); // Redir IN and ON subshell
+	
+	// --- Category 7: Complex Combinations ---
+	total_tests++; pass_count += run_test("(cmd1 < in && (cmd2 | cmd3)) > out || cmd4 << EOF");
+
+	// --- Category 8: Syntax Errors (Should return NULL) ---
+	printf("\n======================================================\n");
+	printf("TESTING SYNTAX ERRORS (Should return [NULL])\n");
+	printf("======================================================\n");
+	total_tests++; pass_count += run_test("| ls");
+	total_tests++; pass_count += run_test("ls |");
+	total_tests++; pass_count += run_test("ls | | wc");
+	total_tests++; pass_count += run_test("&& ls");
+	total_tests++; pass_count += run_test("ls &&");
+	total_tests++; pass_count += run_test("ls >");
+	total_tests++; pass_count += run_test("ls > | wc");
+	total_tests++; pass_count += run_test("(ls");
+	total_tests++; pass_count += run_test("ls )");
+	total_tests++; pass_count += run_test("()"); // Your subshell fix
+
+	printf("\n======================================================\n");
+	printf("Test Suite Finished. (%d tests run)\n", total_tests);
+	printf("======================================================\n");
+
+	return (0);
+}


### PR DESCRIPTION
* Update: Makefile to compile bonus and fixed bug of heredoc.

* close #25. Update: added subshell, passed all tests.

* Close #33. Usable parser, no leaks.

* Refactor: handle_redirs function, redirection field state is an array of type t_redir.

* Update: test suite for refactored parser (AI generated).

* Update: add new functions for testing.

* Refactor: AST redirections are now an array of structs of type t_redir.

* Update: modified shell.c to print array and makefile rule fclean.